### PR TITLE
Add benchmark analysis report

### DIFF
--- a/analysis_report.md
+++ b/analysis_report.md
@@ -1,0 +1,11 @@
+# Benchmark Analysis Report
+
+**Algorithm:** Greedy
+
+- Total cost: 5.16
+- Runtime: 0.000105 seconds
+- Graph size: 10 nodes / 17 edges
+- Solo licenses: 1
+- Family licenses: 2
+
+This report summarizes the results of a single benchmark run produced on 2025-08-18.


### PR DESCRIPTION
## Summary
- Generate benchmark CSV via `scripts.run_benchmark` for the greedy algorithm and analyze results
- Document key metrics like cost, runtime, and license counts in `analysis_report.md`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a363a5ee78832791132ce7b007f9f8